### PR TITLE
Test correct link redirection for the first video on Home Page

### DIFF
--- a/pages/channelPage.ts
+++ b/pages/channelPage.ts
@@ -1,0 +1,13 @@
+import { Page, Locator } from "@playwright/test";
+
+export class ChannelPage {
+    readonly page: Page
+
+    constructor(page: Page){
+        this.page = page
+    }
+
+    async getCurrentUrl(){
+        return this.page.url()
+    }
+}

--- a/pages/firstVideoPage.ts
+++ b/pages/firstVideoPage.ts
@@ -1,0 +1,13 @@
+import { Page, Locator } from "@playwright/test";
+
+export class FirstVideoPage {
+    readonly page: Page
+
+    constructor(page: Page){
+        this.page = page
+    }
+
+    async getCurrentUrl(){
+        return this.page.url()
+    }
+}

--- a/pages/homePage.ts
+++ b/pages/homePage.ts
@@ -15,6 +15,10 @@ export class HomePage {
     readonly newsButton: Locator
     readonly sportsButton: Locator
     readonly podcastsButton: Locator
+    readonly firstVideoThumbnail: Locator
+    readonly firstVideoTitle: Locator
+    readonly firstVideoChannelName: Locator
+    readonly firstVideoChannelAvatar: Locator
 
     constructor(page: Page){
         this.page = page
@@ -31,6 +35,10 @@ export class HomePage {
         this.newsButton = page.getByRole('link', { name: 'News' }).first()
         this.sportsButton = page.getByRole('link', { name: 'Sports' }).first()
         this.podcastsButton = page.getByRole('link', { name: 'Podcasts' }).first()
+        this.firstVideoThumbnail = page.locator('ytd-rich-grid-media ytd-thumbnail #thumbnail').first()
+        this.firstVideoTitle = page.locator('#video-title-link').first()
+        this.firstVideoChannelName = page.locator('ytd-rich-grid-media #channel-name a').first()
+        this.firstVideoChannelAvatar = page.locator('#avatar-link').first()
     }
 
     async goto() {
@@ -105,5 +113,15 @@ export class HomePage {
         await expect(this.podcastsButton).toBeEnabled()
         await this.podcastsButton.click()
         await this.page.waitForURL('/podcasts*')
+    }
+
+    async clickOnVideo(locator: Locator){
+        await locator.click()
+        await this.page.waitForURL('/watch?v=*')
+    }
+
+    async clickOnChannel(locator: Locator){
+        await locator.click()
+        await this.page.waitForURL('/@*')
     }
 }

--- a/tests/web/testLinkRedirection.spec.ts
+++ b/tests/web/testLinkRedirection.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test'
+import { HomePage } from '../../pages/homePage'
+import { testRail, CurrentTest } from '@zebrunner/javascript-agent-playwright'
+import { FirstVideoPage } from '../../pages/firstVideoPage'
+import { ChannelPage } from '../../pages/ChannelPage'
+
+test.describe('Test correct link redirection for the first video on Home Page', () => {
+
+    test('test that clicking on video thumbnail opens the related video', async ({ page }) => {
+        testRail.testCaseId("C3722")
+        CurrentTest.setMaintainer('ygalitsyna')
+        const homePage = new HomePage(page)
+        const firstVideoPage = new FirstVideoPage(page)
+        await homePage.goto()
+        const videoHrefAttr = await homePage.firstVideoThumbnail.getAttribute('href')
+        await homePage.clickOnVideo(homePage.firstVideoThumbnail)
+        const currentUrl = await firstVideoPage.getCurrentUrl()
+        expect(currentUrl).toEqual(`https://www.youtube.com${videoHrefAttr}`)
+    })
+
+    test('test that clicking on video title opens the related video', async ({ page }) => {
+        testRail.testCaseId("C3723")
+        CurrentTest.setMaintainer('ygalitsyna')
+        const homePage = new HomePage(page)
+        const firstVideoPage = new FirstVideoPage(page)
+        await homePage.goto()
+        const videoHrefAttr = await homePage.firstVideoTitle.getAttribute('href')
+        await homePage.clickOnVideo(homePage.firstVideoTitle)
+        const currentUrl = await firstVideoPage.getCurrentUrl()
+        expect(currentUrl).toEqual(`https://www.youtube.com${videoHrefAttr}`)
+    })
+
+    test('test that clicking on video channel name opens the related Channel Page', async ({ page }) => {
+        testRail.testCaseId("C3724")
+        CurrentTest.setMaintainer('ygalitsyna')
+        const homePage = new HomePage(page)
+        const channelPage = new ChannelPage(page)
+        await homePage.goto()
+        const channelHrefAttr = await homePage.firstVideoChannelName.getAttribute('href')
+        await homePage.clickOnChannel(homePage.firstVideoChannelName)
+        const currentUrl = await channelPage.getCurrentUrl()
+        expect(currentUrl).toEqual(`https://www.youtube.com${channelHrefAttr}`)
+    })
+
+    test('test that clicking on video channel avatar opens the related Channel Page', async ({ page }) => {
+        testRail.testCaseId("C3725")
+        CurrentTest.setMaintainer('ygalitsyna')
+        const homePage = new HomePage(page)
+        const channelPage = new ChannelPage(page)
+        await homePage.goto()
+        const channelHrefAttr = await homePage.firstVideoChannelAvatar.getAttribute('href')
+        await homePage.clickOnChannel(homePage.firstVideoChannelAvatar)
+        const currentUrl = await channelPage.getCurrentUrl()
+        expect(currentUrl).toEqual(`https://www.youtube.com${channelHrefAttr}`)
+    })
+})


### PR DESCRIPTION
Add testLinkRedirection.spec.ts to test correct link redirection for the first video on Home Page:
- clicking on video thumbnail opens the related video
- clicking on video title opens the related video
- clicking on video channel name opens the related Channel Page
- clicking on video channel avatar opens the related Channel Page

Add firstVideoPage.ts and channelPage.ts